### PR TITLE
Jest 28 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,10 +37,10 @@ function processSvg(contents, filename)
 	if (parts.ext.toLowerCase() === '.svg')
 	{
 		const functionName = createFunctionName(parts.name);
-		return buildModule(functionName, parts.base, parts.name);
+		return { code: buildModule(functionName, parts.base, parts.name) };
 	}
 	
-	return contents;
+	return { code: contents };
 }
 
 module.exports = 


### PR DESCRIPTION
Hello! The following code changes make this packager compatible with jest 28 — see https://jestjs.io/docs/upgrading-to-jest28#transformer for more details.

Unfortunately I don't think they are backward compatible so I'm not sure how you want to manage this situation… but at least the code is there if you need it.