### PR TITLE
Fix for breaking change in Jest V28. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 const path = require('path');
 
-function buildModule(functionName, pathname, filename)
-{
-	return `
+function buildModule(functionName, pathname, filename) {
+	return {
+		code: `
 const React = require('react');
 
 const ${functionName} = (props) => 
@@ -17,7 +17,8 @@ const ${functionName} = (props) =>
 
 module.exports.default = ${functionName};
 module.exports.ReactComponent = ${functionName};
-`;
+`
+	};
 }
 
 function createFunctionName(base)


### PR DESCRIPTION
Jest V28 has a breaking change, requiring the process function to return an object, rather than a string. This pull request fixes that, however it will probably break for earlier Jest versions. I had a look at the Jest docs, but couldn't spot any way to see which Jest version is running.