### PR TITLE
Fix for Jest 28+

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 function buildModule(functionName, pathname, filename)
 {
-	return `
+	return { code: `
 const React = require('react');
 
 const ${functionName} = (props) => 
@@ -17,7 +17,7 @@ const ${functionName} = (props) =>
 
 module.exports.default = ${functionName};
 module.exports.ReactComponent = ${functionName};
-`;
+`};
 }
 
 function createFunctionName(base)


### PR DESCRIPTION
Updates the return type of the transformer to be 28+ compatible. See more docs here:
https://jestjs.io/docs/28.x/upgrading-to-jest28#transformer